### PR TITLE
refactor(docker-compose): remove `version` from docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ docker run -d --name enclosed --restart unless-stopped -p 8787:8787 -v /path/to/
 You can also use Docker Compose to run the application.
 
 ```yaml
-version: '3.8'
-
 services:
   enclosed:
     image: corentinth/enclosed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   enclosed:
     image: corentinth/enclosed

--- a/packages/docs/src/self-hosting/docker-compose.md
+++ b/packages/docs/src/self-hosting/docker-compose.md
@@ -11,14 +11,12 @@ Ensure that you have Docker and Docker Compose installed on your system. You can
 Below is a sample `docker-compose.yml` file that you can use to deploy Enclosed. This configuration includes options for persistent storage and automatic restart.
 
 ```yaml
-version: '3.8'
-
 services:
   enclosed:
     image: corentinth/enclosed
     container_name: enclosed
     ports:
-      - '8787:8787'
+      - "8787:8787"
     volumes:
       - enclosed-data:/app/.data
     restart: unless-stopped


### PR DESCRIPTION
When running the container via the `docker-compose.yml` this error is given:

`the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion`

[Reference in the compose-spec](https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements)