### PR TITLE
refactor(privacy): no longer rely on google font cdn

### DIFF
--- a/packages/app-client/uno.config.ts
+++ b/packages/app-client/uno.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     }),
     presetAnimations(),
     presetWebFonts({
+      provider: 'bunny',
       fonts: {
         sans: 'Inter:400,500,600,700,800,900',
       },


### PR DESCRIPTION
Use [bunny](https://fonts.bunny.net/) font cdn instead of google