### PR TITLE
Remove 404 URL from robots.txt

### DIFF
--- a/packages/app-client/public/robots.txt
+++ b/packages/app-client/public/robots.txt
@@ -2,4 +2,3 @@ User-agent: *
 Disallow: /
 Allow: /$
 Allow: /og-image.png
-Allow: /docs/


### PR DESCRIPTION
The https://enclosed.cc/docs/ URL goes to a 404 page. Since the docs page is now at https://docs.enclosed.cc

So I've now removed that from the robots.txt file