### PR TITLE
fix(client): fix issue with navigation from a note with the forward/back keys

### DIFF
--- a/packages/app-client/src/modules/notes/notes.constants.ts
+++ b/packages/app-client/src/modules/notes/notes.constants.ts
@@ -1,1 +1,1 @@
-export const NOTE_ID_REGEX = /[0-7][0-9A-HJKMNP-TV-Z]{25}/gi;
+export const NOTE_ID_REGEX = /[0-7][0-9A-HJKMNP-TV-Z]{25}/i;


### PR DESCRIPTION
https://github.com/user-attachments/assets/dbc70fc7-3037-4f6d-8c20-9835fe3bfd1f

This issue happens as the global flag is set on the regex that tests the URL path.
And on Solid JS, the router seems to use [`test`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test#using_test_on_a_regex_with_the_global_flag) to match the URL. Meaning it alternates between `true` and `false`.

Thanks to @Zoobdude for some help!