### PR TITLE
fix(client): hide no file or content error when file is uploaded

### DIFF
--- a/packages/app-client/src/modules/notes/pages/create-note.page.tsx
+++ b/packages/app-client/src/modules/notes/pages/create-note.page.tsx
@@ -119,8 +119,8 @@ export const CreateNotePage: Component = () => {
   }
 
   function updateUploadedFiles(files: File[]) {
-    setUploadedFiles(prevFiles => [...prevFiles, ...files])
-    setError(null)
+    setUploadedFiles(prevFiles => [...prevFiles, ...files]);
+    setError(null);
   }
 
   const getIsShareApiSupported = () => navigator.share !== undefined;

--- a/packages/app-client/src/modules/notes/pages/create-note.page.tsx
+++ b/packages/app-client/src/modules/notes/pages/create-note.page.tsx
@@ -118,6 +118,11 @@ export const CreateNotePage: Component = () => {
     setError(null);
   }
 
+  function updateUploadedFiles(files: File[]) {
+    setUploadedFiles(prevFiles => [...prevFiles, ...files])
+    setError(null)
+  }
+
   const getIsShareApiSupported = () => navigator.share !== undefined;
 
   const shareNote = async () => {
@@ -209,7 +214,7 @@ export const CreateNotePage: Component = () => {
             </TextFieldRoot>
 
             <div>
-              <FileUploaderButton variant="secondary" class="mt-2 w-full" multiple onFilesUpload={({ files }) => setUploadedFiles(prevFiles => [...prevFiles, ...files])}>
+              <FileUploaderButton variant="secondary" class="mt-2 w-full" multiple onFilesUpload={({ files }) => updateUploadedFiles(files)}>
                 <div class="i-tabler-upload mr-2 text-lg text-muted-foreground"></div>
                 {t('create.settings.attach-files')}
               </FileUploaderButton>


### PR DESCRIPTION
Currently typing in the box is the only way to hide the error message, uploading a file does not.
This PR fixes it

Current:

![image](https://github.com/user-attachments/assets/03f02139-4357-4314-af88-5bcdf7eaf6c1)


Fixed:

![image](https://github.com/user-attachments/assets/a833f722-9e5c-429d-9bc3-4e717cf1625e)
