### PR TITLE
feat(ci): Add ARMv7 image builds for older RPIs

### DIFF
--- a/.github/workflows/cd-docker-release.yaml
+++ b/.github/workflows/cd-docker-release.yaml
@@ -170,7 +170,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64, linux/arm/v7
           push: true
           tags: |
             corentinth/enclosed:latest
@@ -183,7 +183,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.rootless
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64, linux/arm/v7
           push: true
           tags: |
             corentinth/enclosed:latest-rootless


### PR DESCRIPTION
While working on #261 I see many other apps provide images for ARM v7. This is used by older Raspberry Pi models (Pi 2).