### PR TITLE
fix(docker): reverted armv7 target platform

### DIFF
--- a/.github/workflows/cd-docker-release.yaml
+++ b/.github/workflows/cd-docker-release.yaml
@@ -170,7 +170,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64, linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             corentinth/enclosed:latest
@@ -183,7 +183,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.rootless
-          platforms: linux/amd64,linux/arm64, linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             corentinth/enclosed:latest-rootless


### PR DESCRIPTION
I'm reverting the build for armv7 in order to fix the release pipeline

Revert #312 
Related to #314 