### PR TITLE
feat(config): add default note TTL configuration

### DIFF
--- a/packages/app-client/src/modules/config/config.constants.ts
+++ b/packages/app-client/src/modules/config/config.constants.ts
@@ -6,4 +6,5 @@ export const buildTimeConfig: Config = {
   enclosedVersion: import.meta.env.VITE_ENCLOSED_VERSION ?? '0.0.0',
   isAuthenticationRequired: import.meta.env.VITE_IS_AUTHENTICATION_REQUIRED === 'true',
   defaultDeleteNoteAfterReading: import.meta.env.VITE_DEFAULT_DELETE_NOTE_AFTER_READING === 'true',
+  defaultNoteTtlSeconds: Number(import.meta.env.VITE_DEFAULT_NOTE_TTL_SECONDS ?? 3600),
 };

--- a/packages/app-client/src/modules/config/config.types.ts
+++ b/packages/app-client/src/modules/config/config.types.ts
@@ -4,4 +4,5 @@ export type Config = {
   isAuthenticationRequired: boolean;
   enclosedVersion: string;
   defaultDeleteNoteAfterReading: boolean;
+  defaultNoteTtlSeconds: number;
 };

--- a/packages/app-client/src/modules/notes/pages/create-note.page.tsx
+++ b/packages/app-client/src/modules/notes/pages/create-note.page.tsx
@@ -118,7 +118,7 @@ export const CreateNotePage: Component = () => {
   const [getError, setError] = createSignal<{ message: string; details?: string } | null>(null);
   const [getIsNoteCreated, setIsNoteCreated] = createSignal(false);
   const [getIsPublic, setIsPublic] = createSignal(true);
-  const [getTtlInSeconds, setTtlInSeconds] = createSignal(3600);
+  const [getTtlInSeconds, setTtlInSeconds] = createSignal(config.defaultNoteTtlSeconds);
   const [getDeleteAfterReading, setDeleteAfterReading] = createSignal(config.defaultDeleteNoteAfterReading);
   const [getUploadedFiles, setUploadedFiles] = createSignal<File[]>([]);
   const [getIsNoteCreating, setIsNoteCreating] = createSignal(false);

--- a/packages/app-server/src/modules/app/config/config.ts
+++ b/packages/app-server/src/modules/app/config/config.ts
@@ -121,6 +121,20 @@ export const configDefinition = {
       default: 'false',
       env: 'PUBLIC_DEFAULT_DELETE_NOTE_AFTER_READING',
     },
+    defaultNoteTtlSeconds: {
+      doc: 'The default value for the expiration time of a note in seconds, the value must be one of: `3600` (1 hour), `86400` (1 day), `604800` (1 week), `2592000` (1 month)',
+      schema: z
+        .coerce
+        .number()
+        .refine(
+          value => [3600, 86400, 604800, 2592000].includes(value),
+          {
+            message: 'PUBLIC_DEFAULT_NOTE_TTL_SECONDS: Invalid value. Must be one of: 3600, 86400, 604800, 2592000',
+          },
+        ),
+      default: 3600,
+      env: 'PUBLIC_DEFAULT_NOTE_TTL_SECONDS',
+    },
   },
   authentication: {
     jwtSecret: {


### PR DESCRIPTION
Closes #322 

Configure the default note expiration delay using
- `PUBLIC_DEFAULT_NOTE_TTL_SECONDS` at runtime (self hosted, or node env)
- `VITE_DEFAULT_NOTE_TTL_SECONDS` at build time (CD pipeline, cloudflare)