### PR TITLE
feat(ui): Improve language dropdown and translation

### DIFF
--- a/packages/app-client/src/locales/en.json
+++ b/packages/app-client/src/locales/en.json
@@ -11,6 +11,11 @@
     "new-note": "New note",
     "github": "GitHub",
     "language": "Language",
+    "github-repository": "GitHub repository",
+    "documentation": "Documentation",
+    "change-theme": "Change theme",
+    "menu-icon": "Menu icon",
+    "change-language": "Change language",
     "theme": {
       "theme": "Theme",
       "light-mode": "Light mode",
@@ -65,7 +70,10 @@
       "placeholder": "Type your note here...",
       "password": {
         "label": "Note password",
-        "placeholder": "Password..."
+        "placeholder": "Password...",
+        "hide-password": "Hide password",
+        "show-password": "Show password",
+        "generate-random-password": "Generate random password"
       },
       "expiration": "Expiration delay",
       "delays": {

--- a/packages/app-client/src/locales/locales.test.ts
+++ b/packages/app-client/src/locales/locales.test.ts
@@ -37,4 +37,9 @@ describe('locales', () => {
       expect(await fileExists(`./${key}.json`)).to.eql(true, `Missing file for locale ${key}`);
     }
   });
+
+  test('make sure locales are sorted by the native language name', () => {
+    const sortedLocales = [...locales].sort((a, b) => a.name.localeCompare(b.name));
+    expect(locales).to.eql(sortedLocales);
+  });
 });

--- a/packages/app-client/src/locales/locales.ts
+++ b/packages/app-client/src/locales/locales.ts
@@ -1,16 +1,16 @@
 // Order of locales matters, keep it sorted by the native language name
 export const locales = [
-  { key: 'ar', name: 'العربية' },
-  { key: 'zh-CN', name: '简体中文' },
   { key: 'de', name: 'Deutsch' },
   { key: 'en', name: 'English' },
   { key: 'es', name: 'Español' },
   { key: 'fr', name: 'Français' },
+  { key: 'it', name: 'Italiano' },
   { key: 'hu', name: 'Magyar' },
   { key: 'nl', name: 'Nederlands' },
-  { key: 'it', name: 'Italiano' },
   { key: 'pt', name: 'Português' },
   { key: 'pt-BR', name: 'Português (Brasil)' },
-  { key: 'ru', name: 'Русский' },
   { key: 'vi', name: 'Tiếng Việt' },
+  { key: 'ru', name: 'Русский' },
+  { key: 'ar', name: 'العربية' },
+  { key: 'zh-CN', name: '简体中文' },
 ] as const;

--- a/packages/app-client/src/modules/i18n/i18n.models.test.ts
+++ b/packages/app-client/src/modules/i18n/i18n.models.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest';
+import { findMatchingLocale } from './i18n.models';
+
+describe('i18n models', () => {
+  describe('findMatchingLocale', () => {
+    test('preferred regional language to regional language', () => {
+      const preferredLocales = ['pt-BR'].map(x => new Intl.Locale(x));
+      const supportedLocales = ['en', 'pt-BR'].map(x => new Intl.Locale(x));
+      const locale = findMatchingLocale({ preferredLocales, supportedLocales });
+
+      expect(locale).toEqual('pt-BR');
+    });
+
+    test('preferred non-regional language to non-regional language', () => {
+      const preferredLocales = ['pt'].map(x => new Intl.Locale(x));
+      const supportedLocales = ['pt-BR', 'pt'].map(x => new Intl.Locale(x));
+      const locale = findMatchingLocale({ preferredLocales, supportedLocales });
+
+      expect(locale).toEqual('pt');
+    });
+
+    test('preferred regional language to non-regional language', () => {
+      const preferredLocales = ['en-GB'].map(x => new Intl.Locale(x));
+      const supportedLocales = ['pt-BR', 'en'].map(x => new Intl.Locale(x));
+      const locale = findMatchingLocale({ preferredLocales, supportedLocales });
+
+      expect(locale).toEqual('en');
+    });
+
+    test('preferred language with different region to supported language', () => {
+      const preferredLocales = ['en-CA'].map(x => new Intl.Locale(x));
+      const supportedLocales = ['fr-FR', 'en-US'].map(x => new Intl.Locale(x));
+      const locale = findMatchingLocale({ preferredLocales, supportedLocales });
+
+      expect(locale).toEqual('en-US');
+    });
+
+    test('preferred language not in supported locales', () => {
+      const preferredLocales = ['it-IT'].map(x => new Intl.Locale(x));
+      const supportedLocales = ['es-ES', 'de-DE'].map(x => new Intl.Locale(x));
+      const locale = findMatchingLocale({ preferredLocales, supportedLocales });
+
+      expect(locale).toEqual('en');
+    });
+
+    test('empty preferred locales', () => {
+      const preferredLocales: Intl.Locale[] = [];
+      const supportedLocales = ['en', 'pt-BR'].map(x => new Intl.Locale(x));
+      const locale = findMatchingLocale({ preferredLocales, supportedLocales });
+
+      expect(locale).toEqual('en');
+    });
+
+    test('empty supported locales', () => {
+      const preferredLocales = ['en-GB', 'pt-BR'].map(x => new Intl.Locale(x));
+      const supportedLocales: Intl.Locale[] = [];
+      const locale = findMatchingLocale({ preferredLocales, supportedLocales });
+
+      expect(locale).toEqual('en');
+    });
+  });
+});

--- a/packages/app-client/src/modules/i18n/i18n.models.ts
+++ b/packages/app-client/src/modules/i18n/i18n.models.ts
@@ -1,0 +1,22 @@
+import type { Locale } from './i18n.provider';
+
+// This tries to get the most preferred language compatible with the supported languages
+// It tries to find a supported language by comparing both region and language, if not, then just language
+// For example:
+// en-GB -> en
+// pt-BR -> pt-BR
+export function findMatchingLocale({ preferredLocales, supportedLocales }: { preferredLocales: Intl.Locale[]; supportedLocales: Intl.Locale[] }) {
+  for (const locale of preferredLocales) {
+    const localeMatchRegion = supportedLocales.find(x => x.baseName === locale.baseName);
+
+    if (localeMatchRegion) {
+      return localeMatchRegion.baseName as Locale;
+    }
+
+    const localeMatchLanguage = supportedLocales.find(x => x.language === locale.language);
+    if (localeMatchLanguage) {
+      return localeMatchLanguage.baseName as Locale;
+    }
+  }
+  return 'en';
+}

--- a/packages/app-client/src/modules/notes/components/note-password-field.tsx
+++ b/packages/app-client/src/modules/notes/components/note-password-field.tsx
@@ -19,11 +19,11 @@ export const NotePasswordField: Component<{ getPassword: () => string; setPasswo
     <div class="border border-input rounded-md flex items-center pr-1">
       <TextField placeholder={t('create.settings.password.placeholder')} value={props.getPassword()} onInput={e => props.setPassword(e.currentTarget.value)} class="border-none shadow-none focus-visible:ring-none" type={getShowPassword() ? 'text' : 'password'} data-test-id={props.dataTestId} />
 
-      <Button variant="link" onClick={() => setShowPassword(!getShowPassword())} class="text-base size-9 p-0 text-muted-foreground hover:text-primary transition" aria-label={getShowPassword() ? 'Hide password' : 'Show password'}>
+      <Button variant="link" onClick={() => setShowPassword(!getShowPassword())} class="text-base size-9 p-0 text-muted-foreground hover:text-primary transition" aria-label={getShowPassword() ? t('create.settings.password.hide-password') : t('create.settings.password.show-password')}>
         <div classList={{ 'i-tabler-eye': !getShowPassword(), 'i-tabler-eye-off': getShowPassword() }}></div>
       </Button>
 
-      <Button variant="link" onClick={generateRandomPassword} class="text-base size-9 p-0 text-muted-foreground hover:text-primary transition" aria-label="Generate random password">
+      <Button variant="link" onClick={generateRandomPassword} class="text-base size-9 p-0 text-muted-foreground hover:text-primary transition" aria-label={t('create.settings.password.generate-random-password')}>
         <div class="i-tabler-refresh"></div>
       </Button>
     </div>

--- a/packages/app-client/src/modules/ui/layouts/app.layout.tsx
+++ b/packages/app-client/src/modules/ui/layouts/app.layout.tsx
@@ -39,20 +39,22 @@ const LanguageSwitcher: Component = () => {
   const { t, getLocale, setLocale, locales } = useI18n();
   const languageName = new Intl.DisplayNames(getLocale(), {
     type: 'language',
-    languageDisplay: 'dialect',
+    languageDisplay: 'standard',
   });
 
   return (
     <>
       {locales.map(locale => (
-        <DropdownMenuItem onClick={() => setLocale(locale.key)} class={cn('cursor-pointer', { 'font-semibold': getLocale() === locale.key })}>
+        <DropdownMenuItem onClick={() => setLocale(locale.key)} class={cn('cursor-pointer', { 'font-bold': getLocale() === locale.key })}>
           {languageName.of(locale.key)}
           <Show when={getLocale() !== locale.key}>
-            {' ('}
-            <span translate="no" lang={locale.key}>
-              {locale.name}
+            <span class={cn('text-muted-foreground pl-1')}>
+              (
+              <span translate="no" lang={locale.key}>
+                {locale.name}
+              </span>
+              )
             </span>
-            )
           </Show>
         </DropdownMenuItem>
       ))}

--- a/packages/app-client/src/modules/ui/layouts/app.layout.tsx
+++ b/packages/app-client/src/modules/ui/layouts/app.layout.tsx
@@ -48,7 +48,7 @@ const LanguageSwitcher: Component = () => {
         <DropdownMenuItem onClick={() => setLocale(locale.key)} class={cn('cursor-pointer', { 'font-bold': getLocale() === locale.key })}>
           {languageName.of(locale.key)}
           <Show when={getLocale() !== locale.key}>
-            <span class={cn('text-muted-foreground pl-1')}>
+            <span class="text-muted-foreground pl-1">
               (
               <span translate="no" lang={locale.key}>
                 {locale.name}

--- a/packages/app-client/src/modules/ui/layouts/app.layout.tsx
+++ b/packages/app-client/src/modules/ui/layouts/app.layout.tsx
@@ -37,12 +37,23 @@ const ThemeSwitcher: Component = () => {
 
 const LanguageSwitcher: Component = () => {
   const { t, getLocale, setLocale, locales } = useI18n();
+  const languageName = new Intl.DisplayNames(getLocale(), {
+    type: 'language',
+    languageDisplay: 'dialect',
+  });
 
   return (
     <>
       {locales.map(locale => (
-        <DropdownMenuItem onClick={() => setLocale(locale.key)} class={cn('flex items-center gap-2 cursor-pointer', { 'font-semibold': getLocale() === locale.key })}>
-          {locale.name}
+        <DropdownMenuItem onClick={() => setLocale(locale.key)} class={cn('cursor-pointer', { 'font-semibold': getLocale() === locale.key })}>
+          {languageName.of(locale.key)}
+          <Show when={getLocale() !== locale.key}>
+            {' ('}
+            <span translate="no" lang={locale.key}>
+              {locale.name}
+            </span>
+            )
+          </Show>
         </DropdownMenuItem>
       ))}
 
@@ -88,12 +99,12 @@ export const Navbar: Component = () => {
             {t('navbar.new-note')}
           </Button>
 
-          <Button variant="ghost" class="text-lg px-0 size-9 hidden md:inline-flex" as={A} href="https://github.com/CorentinTh/enclosed" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository">
+          <Button variant="ghost" class="text-lg px-0 size-9 hidden md:inline-flex" as={A} href="https://github.com/CorentinTh/enclosed" target="_blank" rel="noopener noreferrer" aria-label={t('navbar.github-repository')}>
             <div class="i-tabler-brand-github"></div>
           </Button>
 
           <DropdownMenu>
-            <DropdownMenuTrigger as={Button} class="text-lg px-0 size-9 hidden md:inline-flex" variant="ghost" aria-label="Change theme">
+            <DropdownMenuTrigger as={Button} class="text-lg px-0 size-9 hidden md:inline-flex" variant="ghost" aria-label={t('navbar.change-theme')}>
               <div classList={{ 'i-tabler-moon': themeStore.getColorMode() === 'dark', 'i-tabler-sun': themeStore.getColorMode() === 'light' }}></div>
             </DropdownMenuTrigger>
             <DropdownMenuContent class="w-42">
@@ -102,7 +113,7 @@ export const Navbar: Component = () => {
           </DropdownMenu>
 
           <DropdownMenu>
-            <DropdownMenuTrigger as={Button} class="text-lg px-0 size-9 hidden md:inline-flex" variant="ghost" aria-label="Language">
+            <DropdownMenuTrigger as={Button} class="text-lg px-0 size-9 hidden md:inline-flex" variant="ghost" aria-label={t('navbar.language')}>
               <div class="i-custom-language size-4"></div>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
@@ -112,7 +123,7 @@ export const Navbar: Component = () => {
 
           <DropdownMenu>
 
-            <DropdownMenuTrigger as={Button} class="text-lg px-0 size-9" variant="ghost" aria-label="Menu icon">
+            <DropdownMenuTrigger as={Button} class="text-lg px-0 size-9" variant="ghost" aria-label={t('navbar.menu-icon')}>
               <div class="i-tabler-dots-vertical hidden md:block"></div>
               <div class="i-tabler-menu-2 block md:hidden"></div>
             </DropdownMenuTrigger>
@@ -126,7 +137,7 @@ export const Navbar: Component = () => {
               </DropdownMenuItem>
 
               <DropdownMenuSub>
-                <DropdownMenuSubTrigger as="a" class="flex items-center gap-2 md:hidden" aria-label="Change theme">
+                <DropdownMenuSubTrigger as="a" class="flex items-center gap-2 md:hidden" aria-label={t('navbar.change-theme')}>
                   <div class="text-lg" classList={{ 'i-tabler-moon': themeStore.getColorMode() === 'dark', 'i-tabler-sun': themeStore.getColorMode() === 'light' }}></div>
                   {t('navbar.theme.theme')}
                 </DropdownMenuSubTrigger>
@@ -138,7 +149,7 @@ export const Navbar: Component = () => {
               </DropdownMenuSub>
 
               <DropdownMenuSub>
-                <DropdownMenuSubTrigger as="a" class="flex items-center text-medium gap-2 md:hidden" aria-label="Change language">
+                <DropdownMenuSubTrigger as="a" class="flex items-center text-medium gap-2 md:hidden" aria-label={t('navbar.change-language')}>
                   <div class="i-custom-language size-4"></div>
                   {t('navbar.language')}
                 </DropdownMenuSubTrigger>

--- a/packages/app-client/src/modules/ui/layouts/app.layout.tsx
+++ b/packages/app-client/src/modules/ui/layouts/app.layout.tsx
@@ -46,13 +46,13 @@ const LanguageSwitcher: Component = () => {
     <>
       {locales.map(locale => (
         <DropdownMenuItem onClick={() => setLocale(locale.key)} class={cn('cursor-pointer', { 'font-bold': getLocale() === locale.key })}>
-          {languageName.of(locale.key)}
+          <span translate="no" lang={getLocale() === locale.key ? undefined : locale.key}>
+            {locale.name}
+          </span>
           <Show when={getLocale() !== locale.key}>
             <span class="text-muted-foreground pl-1">
               (
-              <span translate="no" lang={locale.key}>
-                {locale.name}
-              </span>
+              {languageName.of(locale.key)}
               )
             </span>
           </Show>


### PR DESCRIPTION
This PR:
* Prevents a layout shift from happening when switching languages
* Adds more translation keys to missed `aria-label`s
* Updates the document's `lang` attribute to the current language
* In the language dropdown, it shows the language's translated name along with its original name