### PR TITLE
refactor(storage): added some cloudflare KV 413 error management

### DIFF
--- a/packages/app-server/src/modules/storage/factories/cloudflare-kv.storage.models.test.ts
+++ b/packages/app-server/src/modules/storage/factories/cloudflare-kv.storage.models.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+import { looksLikeCloudflare413Error } from './cloudflare-kv.storage.models';
+
+describe('cloudflare-kv storage models', () => {
+  describe('looksLikeCloudflare413Error', () => {
+    test('a cloudflare 413 error starts with "KV PUT failed: 413 Value length of", everything else is not a cloudflare 413 error', () => {
+      expect(looksLikeCloudflare413Error({
+        error: new Error('KV PUT failed: 413 Value length of 41943339 exceeds limit of 26214400.'),
+      })).to.eql(true);
+
+      expect(looksLikeCloudflare413Error({
+        error: new Error('KV PUT failed: 429 Too many requests.'),
+      })).to.eql(false);
+
+      expect(looksLikeCloudflare413Error({ error: undefined })).to.eql(false);
+      expect(looksLikeCloudflare413Error({ error: 'foo' })).to.eql(false);
+    });
+  });
+});

--- a/packages/app-server/src/modules/storage/factories/cloudflare-kv.storage.models.ts
+++ b/packages/app-server/src/modules/storage/factories/cloudflare-kv.storage.models.ts
@@ -1,0 +1,11 @@
+import { isError } from 'lodash-es';
+
+export { looksLikeCloudflare413Error };
+
+function looksLikeCloudflare413Error({ error }: { error: unknown }) {
+  if (isError(error)) {
+    return error?.message?.startsWith('KV PUT failed: 413 Value length of') ?? false;
+  }
+
+  return false;
+}

--- a/packages/app-server/src/modules/storage/factories/cloudflare-kv.storage.ts
+++ b/packages/app-server/src/modules/storage/factories/cloudflare-kv.storage.ts
@@ -1,8 +1,12 @@
 import type { Driver } from 'unstorage';
+import { safely } from '@corentinth/chisels';
 import { createStorage } from 'unstorage';
 import cloudflareKVBindingDriver from 'unstorage/drivers/cloudflare-kv-binding';
 import { createError } from '../../shared/errors/errors';
 import { defineBindableStorageFactory } from '../storage.models';
+import { looksLikeCloudflare413Error } from './cloudflare-kv.storage.models';
+
+export const KV_VALUE_LENGTH_EXCEEDED_ERROR_CODE = 'storage.kv.value_length_exceeds_limit';
 
 export const createCloudflareKVStorageFactory = defineBindableStorageFactory(() => {
   return {
@@ -28,7 +32,22 @@ export const createCloudflareKVStorageFactory = defineBindableStorageFactory(() 
         // Current : https://github.com/unjs/unstorage/blob/v1.10.2/src/drivers/cloudflare-kv-binding.ts
         // Future : https://github.com/unjs/unstorage/blob/main/src/drivers/cloudflare-kv-binding.ts
         async setItem(key, value, options) {
-          return binding.put(key, value, options);
+          const [result, error] = await safely(binding.put(key, value, options));
+
+          if (looksLikeCloudflare413Error({ error })) {
+            throw createError({
+              message: 'Value length exceeds limit',
+              code: KV_VALUE_LENGTH_EXCEEDED_ERROR_CODE,
+              statusCode: 413,
+              isInternal: true,
+            });
+          }
+
+          if (error) {
+            throw error;
+          }
+
+          return result;
         },
       };
 

--- a/packages/app-server/wrangler.toml
+++ b/packages/app-server/wrangler.toml
@@ -5,3 +5,8 @@ pages_build_output_dir = "./dist"
 [[kv_namespaces]]
 binding = "notes"
 id = "b1329cb8560e49d392bed877c9ac48a2"
+
+[vars]
+# Cloudfare KV value max size is 25Mib
+# https://developers.cloudflare.com/kv/platform/limits/
+NOTES_MAX_ENCRYPTED_PAYLOAD_LENGTH = 26214400


### PR DESCRIPTION
closes #337 

- Added some error mapping in the kv storage driver
- Reduced the note creation api size limit of the public instance to KV max storage ([25Mib](https://developers.cloudflare.com/kv/platform/limits/)) for faster feedback

![image](https://github.com/user-attachments/assets/ae76e8a3-635e-4766-9ad2-b9b8b34eb251)
