### PR TITLE
feat(view-note): prevent note password auto-completion from auth password

### DIFF
--- a/packages/app-client/src/modules/notes/components/note-password-field.tsx
+++ b/packages/app-client/src/modules/notes/components/note-password-field.tsx
@@ -17,7 +17,7 @@ export const NotePasswordField: Component<{ getPassword: () => string; setPasswo
 
   return (
     <div class="border border-input rounded-md flex items-center pr-1">
-      <TextField placeholder={t('create.settings.password.placeholder')} value={props.getPassword()} onInput={e => props.setPassword(e.currentTarget.value)} class="border-none shadow-none focus-visible:ring-none" type={getShowPassword() ? 'text' : 'password'} data-test-id={props.dataTestId} />
+      <TextField placeholder={t('create.settings.password.placeholder')} value={props.getPassword()} onInput={e => props.setPassword(e.currentTarget.value)} class="border-none shadow-none focus-visible:ring-none" type={getShowPassword() ? 'text' : 'password'} autocomplete="new-password" data-test-id={props.dataTestId} />
 
       <Button variant="link" onClick={() => setShowPassword(!getShowPassword())} class="text-base size-9 p-0 text-muted-foreground hover:text-primary transition" aria-label={getShowPassword() ? t('create.settings.password.hide-password') : t('create.settings.password.show-password')}>
         <div classList={{ 'i-tabler-eye': !getShowPassword(), 'i-tabler-eye-off': getShowPassword() }}></div>

--- a/packages/app-client/src/modules/notes/pages/view-note.page.tsx
+++ b/packages/app-client/src/modules/notes/pages/view-note.page.tsx
@@ -41,7 +41,7 @@ const RequestPasswordForm: Component<{ onPasswordEntered: (args: { password: str
             <div>
               <TextFieldRoot>
                 <TextFieldLabel>{t('view.request-password.form.label')}</TextFieldLabel>
-                <TextField type="password" placeholder={t('view.request-password.form.placeholder')} value={getPassword()} onInput={e => updatePassword(e.currentTarget.value)} autofocus data-test-id="note-password-prompt" />
+                <TextField type="password" autocomplete="new-password" placeholder={t('view.request-password.form.placeholder')} value={getPassword()} onInput={e => updatePassword(e.currentTarget.value)} autofocus data-test-id="note-password-prompt" />
               </TextFieldRoot>
             </div>
             <Button class="w-full mt-4" type="submit" data-test-id="note-password-submit">


### PR DESCRIPTION
Case reproduction:

- Configuring the enclosed instance with user authentication
- Log in to application (login/password) and save info in Firefox
- When you reach the note creation page, the password is automatically filled in with the password of the logged-in user.

![image](https://github.com/user-attachments/assets/7a9a0809-e084-477f-9737-f93f8165e5dd)

This PR proposes adding the autocomplete=“new-password” attribute to inputs of type “password” on the page: packages/app-client/src/modules/notes/pages/view-note.page.tsx and in the component : 
packages/app-client/src/modules/notes/components/note-password-field.tsx

These changes fix this autocompletion problem.

Thank you for your work