### PR TITLE
fix(docker): run the default image as a non-root user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git
+.github
 .output
 .data
 .nuxt

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN pnpm --filter @enclosed/crypto run build && \
     pnpm --filter @enclosed/app-client run build && \
     pnpm --filter @enclosed/app-server run build:node
 
-# Production image 
+# Production image
 FROM node:22-alpine
 
 WORKDIR /app
@@ -35,9 +35,15 @@ WORKDIR /app
 COPY --from=builder /app/packages/app-client/dist ./public
 COPY --from=builder /app/packages/app-server/dist-node/index.cjs ./index.cjs
 
-# Create the .data directory 
-RUN mkdir -p /app/.data 
+# Create the .data directory and hand ownership to the built-in unprivileged
+# `node` user so the container does not run as root.
+RUN mkdir -p /app/.data && chown -R node:node /app
+
+USER node
 
 EXPOSE 8787
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8787/api/ping || exit 1
 
 CMD ["node", "index.cjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,19 @@ services:
     volumes:
       - enclosed-data:/app/.data
     restart: unless-stopped
+    # Defense-in-depth hardening for the reference deployment.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    # Set a strong secret and enable auth if this instance is not meant to be public:
+    # environment:
+    #   AUTHENTICATION_JWT_SECRET: "<openssl rand -base64 48>"
+    #   PUBLIC_IS_AUTHENTICATION_REQUIRED: "true"
+    #   AUTHENTICATION_USERS: "you@example.com:<bcrypt-hash>"
 
 volumes:
   enclosed-data:


### PR DESCRIPTION
The default `Dockerfile` runs the container as **root** (only `Dockerfile.rootless` drops privileges, and it isn't the image the reference `docker-compose.yml` uses).

- Run the final image as the built-in unprivileged `node` user (`chown` `/app` + `USER node`).
- Add a `HEALTHCHECK` hitting `/api/ping`.
- Exclude `.git` / `.github` from the build context in `.dockerignore` (the builder stage does `COPY . .`).
- Add `no-new-privileges`, `cap_drop: [ALL]` and `read_only` (with a `tmpfs` for `/tmp`) to the reference compose file, plus a commented-out example of setting a strong `AUTHENTICATION_JWT_SECRET`.

No application behaviour changes.
