### PR TITLE
feat(security): add CSP, Permissions-Policy and a request body limit

### DIFF
--- a/packages/app-server/src/modules/app/server.ts
+++ b/packages/app-server/src/modules/app/server.ts
@@ -2,6 +2,7 @@ import type { BindableStorageFactory } from '../storage/storage.types';
 import type { Config } from './config/config.types';
 import type { ServerInstanceGenerics } from './server.types';
 import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import { secureHeaders } from 'hono/secure-headers';
 import { registerNotesRoutes } from '../notes/notes.routes';
 import { authenticationMiddleware } from './auth/auth.middleware';
@@ -16,15 +17,48 @@ import { timeoutMiddleware } from './middlewares/timeout.middleware';
 
 export { createServer };
 
+// 50MB is the default max encrypted payload; allow a small envelope for the
+// surrounding JSON fields. Reject oversized bodies while streaming instead of
+// buffering the whole request into memory first (memory-exhaustion DoS).
+const DEFAULT_MAX_PAYLOAD_BYTES = 1024 * 1024 * 50;
+const BODY_ENVELOPE_OVERHEAD_BYTES = 1024 * 4;
+
 function createServer({ config, storageFactory }: { config?: Config; storageFactory: BindableStorageFactory }) {
   const app = new Hono<ServerInstanceGenerics>({ strict: true });
+
+  const maxBodyBytes = (config?.notes.maxEncryptedPayloadLength ?? DEFAULT_MAX_PAYLOAD_BYTES) + BODY_ENVELOPE_OVERHEAD_BYTES;
 
   app.use(loggerMiddleware);
   app.use(createConfigMiddleware({ config }));
   app.use(timeoutMiddleware);
   app.use(corsMiddleware);
   app.use(createStorageMiddleware({ storageFactory }));
-  app.use(secureHeaders());
+  app.use(secureHeaders({
+    contentSecurityPolicy: {
+      defaultSrc: ['\'self\''],
+      scriptSrc: ['\'self\''],
+      // The client bundles styles and needs inline styles for theming.
+      styleSrc: ['\'self\'', '\'unsafe-inline\''],
+      imgSrc: ['\'self\'', 'data:'],
+      connectSrc: ['\'self\''],
+      fontSrc: ['\'self\'', 'data:'],
+      objectSrc: ['\'none\''],
+      baseUri: ['\'self\''],
+      frameAncestors: ['\'none\''],
+      formAction: ['\'self\''],
+    },
+    permissionsPolicy: {
+      camera: [],
+      microphone: [],
+      geolocation: [],
+      payment: [],
+      usb: [],
+    },
+  }));
+  app.use(bodyLimit({
+    maxSize: maxBodyBytes,
+    onError: context => context.json({ error: { code: 'note.payload_too_large', message: 'Request body too large.' } }, 413),
+  }));
   app.use(authenticationMiddleware);
 
   registerErrorMiddleware({ app });


### PR DESCRIPTION
Two small HTTP-layer hardening changes in `server.ts`:

- **Security headers:** `secureHeaders()` was called with no options, so no `Content-Security-Policy` or `Permissions-Policy` was emitted (HSTS / nosniff / X-Frame-Options were already on by default). Adds an explicit CSP (`default-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, …) and a minimal `Permissions-Policy`. The CSP allows `'unsafe-inline'` for styles and `data:` images/fonts, which the client currently needs.
- **Request body limit:** adds `hono/body-limit` sized to `maxEncryptedPayloadLength` (+ envelope). Without it, request bodies were fully buffered and JSON-parsed into memory *before* the per-note size check, so an oversized body was buffered in full before rejection. With the limit, oversized bodies are rejected while streaming.

Lint, typecheck, tests and build pass.
