### PR TITLE
refactor(notes): use non-monotonic ULIDs for note ids

### DIFF
--- a/packages/app-server/src/modules/shared/utils/random.ts
+++ b/packages/app-server/src/modules/shared/utils/random.ts
@@ -2,7 +2,11 @@ import { ulidFactory } from 'ulid-workers';
 
 export { generateId };
 
-const createUlid = ulidFactory();
+// monotonic: false — in monotonic mode ids created within the same millisecond
+// are a deterministic +1 of the previous random suffix instead of fresh entropy,
+// making burst-created ids partly predictable. We don't need sortability for a
+// capability id, so keep the full 80 bits of randomness per id.
+const createUlid = ulidFactory({ monotonic: false });
 
 function generateId() {
   return createUlid().toLowerCase();


### PR DESCRIPTION
`generateId()` uses `ulidFactory()`, which defaults to `monotonic: true`. In monotonic mode, ids minted within the same millisecond are a deterministic `+1` of the previous random suffix rather than fresh randomness.

Note ids are used as capability identifiers, not for sorting, so there's no reason to trade away entropy. Passing `{ monotonic: false }` keeps the full 80 bits of randomness per id. Small, self-contained change.
